### PR TITLE
Fix for empty rules

### DIFF
--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/RuleExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/RuleExecutor.java
@@ -48,6 +48,12 @@ public class RuleExecutor extends AsyncCommandExecutorBase
 	{
 		ArrayList<String> rules = Utils.getRules();
 		List<Text> ruleText = Lists.newArrayList();
+		
+		if (rules.isEmpty())
+		{
+			src.sendMessage(Text.of(TextColors.DARK_RED, "Error! ", TextColors.RED, "The rules for this server are not defined."));
+			return;
+		}
 
 		for (String rule : rules)
 		{


### PR DESCRIPTION
Previously, when no rules were defined for a server, pagination would take over and throw a "Page 1 is too high" error. With this, EssentialCmds will throw a more proper error message, specifying clearly that the rules are not defined.
