### PR TITLE
Fixed Updatifier - Now it works on SpongeVanilla

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,6 @@ targetCompatibility = 1.8
 
 defaultTasks 'licenseFormat'
 
-jar {
-    manifest {
-        attributes 'Implementation-Title': 'EssentialCmds',
-                   'Implementation-Version': version
-    }
-}
-
 repositories {
     jcenter()
     maven {
@@ -36,9 +29,24 @@ repositories {
     }
 }
 
+configurations {
+    shade
+    compile.extendsFrom shade
+}
+
 dependencies {
     compile "org.spongepowered:spongeapi:3.1.0-SNAPSHOT"
-    compile "com.github.Flibio:Updatifier:v1.0.0"
+    shade "com.github.Flibio:Updatifier:v1.3.0:api"
+}
+
+jar {
+    configurations.shade.copyRecursive().setTransitive(false).each { artifact ->
+        from (zipTree(artifact))
+    }
+    manifest {
+        attributes 'Implementation-Title': 'EssentialCmds',
+                   'Implementation-Version': version
+    }
 }
 
 test {

--- a/src/main/java/io/github/hsyyid/essentialcmds/PluginInfo.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/PluginInfo.java
@@ -32,6 +32,6 @@ public abstract class PluginInfo
 	public static final String ID = "EssentialCmds";
 	public static final String NAME = "EssentialCmds";
 	public static final String VERSION = "@project.version@";
-	public static final String DEPENDENCIES = "after:Updatifier";
+	public static final String DEPENDENCIES = "";
 	public static final String INFORMATIVE_VERSION = "@project.informativeVersion@";
 }


### PR DESCRIPTION
Note: Once you ship the annotation, you no longer need to load after Updatifier.
This could make Updatifier work properly without adding `01` before its jar's name. In the production jar, the Updatifier api will be included, which only contains the annotation and an abstract `UpdatifierService`.
