### PR TITLE
Not be so lazy in checking passable property

### DIFF
--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/JumpExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/JumpExecutor.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.data.property.block.PassableProperty;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.blockray.BlockRay;
 import org.spongepowered.api.util.blockray.BlockRayHit;
 import org.spongepowered.api.world.World;
@@ -60,9 +61,7 @@ public class JumpExecutor extends CommandExecutorBase
 			{
 				BlockRayHit<World> currentHitRay = playerBlockRay.next();
 
-				//If the block it hit was air or a passable block such as tall grass, keep going.
-				if (!player.getWorld().getBlockType(currentHitRay.getBlockPosition()).equals(BlockTypes.AIR) &&
-					!currentHitRay.getLocation().getProperty(PassableProperty.class).get().getValue())
+				if (!player.getWorld().getBlockType(currentHitRay.getBlockPosition()).equals(BlockTypes.AIR))
 				{
 					finalHitRay = currentHitRay;
 					break;
@@ -75,8 +74,26 @@ public class JumpExecutor extends CommandExecutorBase
 			}
 			else
 			{
-				// Add 1 so that players do not spawn in the block
-				if (player.setLocationSafely(finalHitRay.getLocation().add(0, 1, 0)))
+				boolean safely = false;
+				// If not passable, then it is a solid block
+				if (!finalHitRay.getLocation().getProperty(PassableProperty.class).get().getValue())
+				{
+					safely = player.setLocationSafely(finalHitRay.getLocation().add(0, 1, 0));
+				}
+				else
+				{
+					// If the block below this is tall grass or a tall flower, then teleport down to that
+					if (finalHitRay.getLocation().getRelative(Direction.DOWN).getProperty(PassableProperty.class).get().getValue())
+					{
+						safely = player.setLocationSafely(finalHitRay.getLocation().sub(0, 1, 0));
+					}
+					else
+					{
+						// If not then we found our location
+						safely = player.setLocationSafely(finalHitRay.getLocation());
+					}
+				}
+				if (safely)
 				{
 					player.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Jumped to the block you were looking at."));
 				}


### PR DESCRIPTION
So recently, I've had a change of heart on how this should be handled. Previously, it would just ignore blocks like grass, however with this, it does not ignore grass and simply checks if a block is passable or not to see where to teleport to.

With this:
- If the `finalHitRay` is not passable (a block), teleport up so a player is not in the ground after teleporting.
- If the `finalHitRay` is passable but the block below it is not, then teleporting there is fine.
- If the `finalHitRay` is passable and the block below it is passable, then the block may be tall grass or a tall flower and the player should be teleported one block below so that they are on the ground. Note that if they teleport to the bottom part of tall grass, then their location will not be affected, as the block below that is a solid block.
