### PR TITLE
Fix /mobspawn and /mobspawner commands

### DIFF
--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/MobSpawnExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/MobSpawnExecutor.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
@@ -66,7 +67,12 @@ public class MobSpawnExecutor extends CommandExecutorBase
 
 			if (type == null)
 			{
-				src.sendMessage(Text.of(TextColors.DARK_RED, "Error! ", TextColors.RED, "The mob you inputed was not recognized."));
+				src.sendMessage(Text.of(TextColors.DARK_RED, "Error! ", TextColors.RED, "The mob you inputted was not recognized."));
+				return CommandResult.success();
+			}
+
+			if (!Living.class.isAssignableFrom(type.getEntityClass())) {
+				src.sendMessage(Text.of(TextColors.DARK_RED, "Error! ", TextColors.RED, "The mob type you inputted is not a living entity."));
 				return CommandResult.success();
 			}
 

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/MobSpawnerExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/MobSpawnerExecutor.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -58,6 +59,11 @@ public class MobSpawnerExecutor extends CommandExecutorBase
 			EntityType type = Sponge.getRegistry().getType(EntityType.class, entityType).orElse(null);
 			if (type != null)
 			{
+				if (!Living.class.isAssignableFrom(type.getEntityClass())) {
+					src.sendMessage(Text.of(TextColors.DARK_RED, "Error! ", TextColors.RED, "The mob type you inputted is not a living entity."));
+					return CommandResult.success();
+				}
+
 				ItemStack.Builder itemBuilder = EssentialCmds.getEssentialCmds().getGame().getRegistry().createBuilder(ItemStack.Builder.class);
 				ItemStack mobSpawnerStack = itemBuilder.itemType(ItemTypes.MOB_SPAWNER).quantity(1).build();
 				Optional<MobSpawnerData> optionalMobSpawnerData = mobSpawnerStack.getOrCreate(MobSpawnerData.class);


### PR DESCRIPTION
They now do not accept non-living entities. Testing on Nucleus showed that if you try to spawn in "minecraft:painting", for example, the entire server froze.

This will be important for servers that allow players to spawn in mobs - if this is known, a malicious user can take down an entire server.
