### PR TITLE
Update BroadcastExecutor.java for working links

### DIFF
--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
@@ -25,7 +25,6 @@
 package io.github.hsyyid.essentialcmds.cmdexecutors;
 
 import io.github.hsyyid.essentialcmds.internal.AsyncCommandExecutorBase;
-
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;
@@ -125,7 +124,7 @@ public class BroadcastExecutor extends AsyncCommandExecutorBase
 	@Nonnull
 	@Override
 	public CommandSpec getSpec() {
-		return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
-		.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();
+			return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
+						.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();
 	}	
 }

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of EssentialCmds, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2015 - 2016 HassanS6000
+ * Copyright (c) 2015 - 2015 HassanS6000
  * Copyright (c) contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of EssentialCmds, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2015 - 2015 HassanS6000
+ * Copyright (c) 2015 - 2016 HassanS6000
  * Copyright (c) contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -31,18 +31,15 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.text.Text;
-
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.spongepowered.api.text.action.TextActions;
 import javax.annotation.Nonnull;
 
@@ -50,90 +47,85 @@ import javax.annotation.Nonnull;
 public class BroadcastExecutor extends AsyncCommandExecutorBase
 {
 
-    @Override
-    public void executeAsync(CommandSource src, CommandContext ctx) {
-	
-    String message = ctx.<String> getOne("message").get();
-	Text msg = TextSerializers.formattingCode('&').deserialize(message);
-	Text broadcast = Text.of(TextColors.DARK_GRAY, "[", TextColors.DARK_RED, "Broadcast", TextColors.DARK_GRAY, "]", TextColors.GREEN, " ");
-	Text finalBroadcast = Text.builder().append(broadcast).append(msg).build();
-	String mssge = Text.of(message).toPlain();
-	if ((message.contains("https://")) || (message.contains("http://"))){
-	List<String> extractedUrls = extractUrls(message);
-	for (String url : extractedUrls){
-	List<String> extractmb = extractmbefore(mssge);
-	for (String preurl : extractmb) {
-	List<String> extractma = extractmafter(mssge);
-	for (String posturl : extractma) {
-		try {
-			String preurlline = preurl.replaceAll("(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*).*?)(?=\\w).*","");
-			String posturlline = posturl.replaceAll("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)","");
-			Text Postmessage= Text.builder(posturlline).build();
-			Text Premessage = Text.builder(preurlline).build();
-			Text linkmessage = Text.builder(url).onClick(TextActions.openUrl(new URL(url))).build();
-			Text newmessage = Text.builder().append(Premessage).append(linkmessage).append(Postmessage).build();
-			Text Glory = Text.builder().append(broadcast).append(newmessage).build();
-			MessageChannel.TO_ALL.send(Glory);}
-		catch (MalformedURLException e) {
-		// TODO Auto-generated catch block
-		e.printStackTrace();}}}}}
-    	else  {
-    		MessageChannel.TO_ALL.send(finalBroadcast);
-    	}
+	@Override
+	public void executeAsync(CommandSource src, CommandContext ctx) {
+			String message = ctx.<String> getOne("message").get();
+			Text msg = TextSerializers.formattingCode('&').deserialize(message);
+			Text broadcast = Text.of(TextColors.DARK_GRAY, "[", TextColors.DARK_RED, "Broadcast", TextColors.DARK_GRAY, "]", TextColors.GREEN, " ");
+			Text finalBroadcast = Text.builder().append(broadcast).append(msg).build();
+			String mssge = Text.of(message).toPlain();
+			
+			if ((message.contains("https://")) || (message.contains("http://"))){
+			
+			List<String> extractedUrls = extractUrls(message);
+				for (String url : extractedUrls){
+			List<String> extractmb = extractmbefore(mssge);
+				for (String preurl : extractmb) {
+			List<String> extractma = extractmafter(mssge);
+					for (String posturl : extractma) {
+						try {
+							String preurlline = preurl.replaceAll("(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*).*?)(?=\\w).*","");
+							String posturlline = posturl.replaceAll("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)","");
+							Text Postmessage= Text.builder(posturlline).build();
+							Text Premessage = Text.builder(preurlline).build();
+							Text linkmessage = Text.builder(url).onClick(TextActions.openUrl(new URL(url))).build();
+							Text newmessage = Text.builder().append(Premessage).append(linkmessage).append(Postmessage).build();
+							Text Finallinkmessage = Text.builder().append(broadcast).append(newmessage).build();
+							MessageChannel.TO_ALL.send(Finallinkmessage);}
+						catch (MalformedURLException e) {
+							e.printStackTrace();}}}}}
+    		else  {
+    				MessageChannel.TO_ALL.send(finalBroadcast);
+    				}
+				}
+
+	public static List<String> extractUrls(String text) {
+					List<String> containedUrls = new ArrayList<String>();
+					String urlRegex = "((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)";
+					Pattern pattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
+					Matcher urlMatcher = pattern.matcher(text);					
+			while (urlMatcher.find())
+				{
+				containedUrls.add(text.substring(urlMatcher.start(0),
+				urlMatcher.end(0)));
+			}
+			return containedUrls;
 	}
 
-	public static List<String> extractUrls(String text)
-	{
-		List<String> containedUrls = new ArrayList<String>();
-		String urlRegex = "((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)";
-		Pattern pattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
-		Matcher urlMatcher = pattern.matcher(text);
-		while (urlMatcher.find())
-		{
-		containedUrls.add(text.substring(urlMatcher.start(0),
-		urlMatcher.end(0)));
-		}
-		return containedUrls;
+	public static List<String> extractmbefore(String pretext) {
+			List<String> preurlmess = new ArrayList<String>();
+			String preurlRegex = ".*((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)(.*)";
+			Pattern prepattern = Pattern.compile(preurlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
+			Matcher preMessage = prepattern.matcher(pretext);
+			while (preMessage.find()) {
+				preurlmess.add(pretext.substring(preMessage.start(0),
+				preMessage.end(0)));
+			}
+			return preurlmess;
 	}
 
-	public static List<String> extractmbefore(String pretext)
-	{
-		List<String> preurlmess = new ArrayList<String>();
-		String preurlRegex = ".*((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)(.*)";
-		Pattern prepattern = Pattern.compile(preurlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
-		Matcher preMessage = prepattern.matcher(pretext);
-		while (preMessage.find())
-		{
-		preurlmess.add(pretext.substring(preMessage.start(0),
-		preMessage.end(0)));
-		}
-		return preurlmess;
-		}
-
-	public static List<String> extractmafter(String posttext)
-	{
-		List<String> posturlmess = new ArrayList<String>();
-		String posturlRegex = "(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]).*)";
-		Pattern postpattern = Pattern.compile(posturlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
-		Matcher postMessage = postpattern.matcher(posttext);
-		while (postMessage.find())
-		{
-		posturlmess.add(posttext.substring(postMessage.start(0),
-		postMessage.end(0)));
-		}
-		return posturlmess;
-		}
+	public static List<String> extractmafter(String posttext) {
+			List<String> posturlmess = new ArrayList<String>();
+			String posturlRegex = "(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]).*)";
+			Pattern postpattern = Pattern.compile(posturlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
+			Matcher postMessage = postpattern.matcher(posttext);
+			while (postMessage.find()) {
+						posturlmess.add(posttext.substring(postMessage.start(0),
+								postMessage.end(0)));
+			}
+			return posturlmess;
+	}
 
 	@Nonnull
 	@Override
 	public String[] getAliases() {
-		return new String[] { "broadcast", "bc" };
+			return new String[] { "broadcast", "bc" };
 	}
 
 	@Nonnull
 	@Override
 	public CommandSpec getSpec() {
-	return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
-	.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();	
-	}
+		return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
+		.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();
+	}	
 }

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/BroadcastExecutor.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of EssentialCmds, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2015 - 2015 HassanS6000
+ * Copyright (c) 2015 - 2016 HassanS6000
  * Copyright (c) contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,27 +25,104 @@
 package io.github.hsyyid.essentialcmds.cmdexecutors;
 
 import io.github.hsyyid.essentialcmds.internal.AsyncCommandExecutorBase;
+
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.text.Text;
+
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.spongepowered.api.text.action.TextActions;
 import javax.annotation.Nonnull;
+
 
 public class BroadcastExecutor extends AsyncCommandExecutorBase
 {
-	@Override
-	public void executeAsync(CommandSource src, CommandContext ctx) {
-		String message = ctx.<String> getOne("message").get();
-		Text msg = TextSerializers.formattingCode('&').deserialize(message);
-		Text broadcast = Text.of(TextColors.DARK_GRAY, "[", TextColors.DARK_RED, "Broadcast", TextColors.DARK_GRAY, "]", TextColors.GREEN, " ");
-		Text finalBroadcast = Text.builder().append(broadcast).append(msg).build();
-		MessageChannel.TO_ALL.send(finalBroadcast);
+
+    @Override
+    public void executeAsync(CommandSource src, CommandContext ctx) {
+	
+    String message = ctx.<String> getOne("message").get();
+	Text msg = TextSerializers.formattingCode('&').deserialize(message);
+	Text broadcast = Text.of(TextColors.DARK_GRAY, "[", TextColors.DARK_RED, "Broadcast", TextColors.DARK_GRAY, "]", TextColors.GREEN, " ");
+	Text finalBroadcast = Text.builder().append(broadcast).append(msg).build();
+	String mssge = Text.of(message).toPlain();
+	if ((message.contains("https://")) || (message.contains("http://"))){
+	List<String> extractedUrls = extractUrls(message);
+	for (String url : extractedUrls){
+	List<String> extractmb = extractmbefore(mssge);
+	for (String preurl : extractmb) {
+	List<String> extractma = extractmafter(mssge);
+	for (String posturl : extractma) {
+		try {
+			String preurlline = preurl.replaceAll("(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*).*?)(?=\\w).*","");
+			String posturlline = posturl.replaceAll("((https?|ftp|gopher|telnet|file|Unsure|http):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)","");
+			Text Postmessage= Text.builder(posturlline).build();
+			Text Premessage = Text.builder(preurlline).build();
+			Text linkmessage = Text.builder(url).onClick(TextActions.openUrl(new URL(url))).build();
+			Text newmessage = Text.builder().append(Premessage).append(linkmessage).append(Postmessage).build();
+			Text Glory = Text.builder().append(broadcast).append(newmessage).build();
+			MessageChannel.TO_ALL.send(Glory);}
+		catch (MalformedURLException e) {
+		// TODO Auto-generated catch block
+		e.printStackTrace();}}}}}
+    	else  {
+    		MessageChannel.TO_ALL.send(finalBroadcast);
+    	}
 	}
+
+	public static List<String> extractUrls(String text)
+	{
+		List<String> containedUrls = new ArrayList<String>();
+		String urlRegex = "((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)";
+		Pattern pattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
+		Matcher urlMatcher = pattern.matcher(text);
+		while (urlMatcher.find())
+		{
+		containedUrls.add(text.substring(urlMatcher.start(0),
+		urlMatcher.end(0)));
+		}
+		return containedUrls;
+	}
+
+	public static List<String> extractmbefore(String pretext)
+	{
+		List<String> preurlmess = new ArrayList<String>();
+		String preurlRegex = ".*((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]*)(.*)";
+		Pattern prepattern = Pattern.compile(preurlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
+		Matcher preMessage = prepattern.matcher(pretext);
+		while (preMessage.find())
+		{
+		preurlmess.add(pretext.substring(preMessage.start(0),
+		preMessage.end(0)));
+		}
+		return preurlmess;
+		}
+
+	public static List<String> extractmafter(String posttext)
+	{
+		List<String> posturlmess = new ArrayList<String>();
+		String posturlRegex = "(((https?|ftp|gopher|telnet|file):((//)|(\\\\))+[\\w\\d:#@%/;$()~_?\\+-=\\\\\\.&]).*)";
+		Pattern postpattern = Pattern.compile(posturlRegex, Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
+		Matcher postMessage = postpattern.matcher(posttext);
+		while (postMessage.find())
+		{
+		posturlmess.add(posttext.substring(postMessage.start(0),
+		postMessage.end(0)));
+		}
+		return posturlmess;
+		}
 
 	@Nonnull
 	@Override
@@ -56,7 +133,7 @@ public class BroadcastExecutor extends AsyncCommandExecutorBase
 	@Nonnull
 	@Override
 	public CommandSpec getSpec() {
-		return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
-				.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();
+	return CommandSpec.builder().description(Text.of("Broadcast Command")).permission("essentialcmds.broadcast.use")
+	.arguments(GenericArguments.remainingJoinedStrings(Text.of("message"))).executor(this).build();	
 	}
 }


### PR DESCRIPTION
The changes I made are solely to the BroadcastExecutor, I added a RegEx that ran through checks after the message was confirmed to have a link (http or https). If it had them, three regEx were ran. One for all of the message before the link, one for the link itself, and one for all the message after the link. Basically it cuts the message into parts and reforms them. If it doesn't have a link(https or http) then it simply runs the old command. I'd appreciate any criticism as I'm just learning Java, but I would love to assist you in this. This fix may also be applicable to normal chat also; I just haven't tinkered with it quite yet. 
