### PR TITLE
Make /delhome, /home, /delwarp and /warp ignore name case

### DIFF
--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/DeleteHomeExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/DeleteHomeExecutor.java
@@ -49,8 +49,9 @@ public class DeleteHomeExecutor extends AsyncCommandExecutorBase
 
 			if (Utils.isHomeInConfig(player.getUniqueId(), homeName))
 			{
+				String configHomeName = Utils.getConfigHomeName(player.getUniqueId(), homeName);
 				Utils.deleteHome(player, homeName);
-				src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Deleted home " + homeName));
+				src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Deleted home " + configHomeName));
 			}
 			else
 			{

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/DeleteWarpExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/DeleteWarpExecutor.java
@@ -43,8 +43,9 @@ public class DeleteWarpExecutor extends AsyncCommandExecutorBase
 
 		if (Utils.isWarpInConfig(warpName))
 		{
+			String configWarpName = Utils.getConfigWarpName(warpName);
 			Utils.deleteWarp(warpName);
-			src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Deleted warp " + warpName));
+			src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Deleted warp " + configWarpName));
 		}
 		else
 		{

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/HomeExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/HomeExecutor.java
@@ -62,7 +62,7 @@ public class HomeExecutor extends CommandExecutorBase
 					if (Utils.isTeleportCooldownEnabled() && !player.hasPermission("essentialcmds.teleport.cooldown.override"))
 					{
 						EssentialCmds.teleportingPlayers.add(player.getUniqueId());
-						src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleporting to Home. Please wait " + Utils.getTeleportCooldown() + " seconds."));
+						src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleporting to home " + Utils.getConfigHomeName(player.getUniqueId(), homeName) + ". Please wait " + Utils.getTeleportCooldown() + " seconds."));
 
 						Sponge.getScheduler().createTaskBuilder().execute(() -> {
 							if (EssentialCmds.teleportingPlayers.contains(player.getUniqueId()))
@@ -79,7 +79,7 @@ public class HomeExecutor extends CommandExecutorBase
 									player.setTransform(Utils.getHome(player.getUniqueId(), homeName));
 								}
 
-								src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to Home " + homeName));
+								src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to home " + Utils.getConfigHomeName(player.getUniqueId(), homeName)));
 								EssentialCmds.teleportingPlayers.remove(player.getUniqueId());
 							}
 						}).delay(Utils.getTeleportCooldown(), TimeUnit.SECONDS).name("EssentialCmds - Back Timer").submit(Sponge.getGame().getPluginManager().getPlugin(PluginInfo.ID).get().getInstance().get());
@@ -98,7 +98,7 @@ public class HomeExecutor extends CommandExecutorBase
 							player.setTransform(Utils.getHome(player.getUniqueId(), homeName));
 						}
 
-						src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to Home " + homeName));
+						src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to home " + Utils.getConfigHomeName(player.getUniqueId(), homeName)));
 					}
 				}
 				catch (PositionOutOfBoundsException e)

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/SetHomeExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/SetHomeExecutor.java
@@ -60,6 +60,10 @@ public class SetHomeExecutor extends AsyncCommandExecutorBase
 			{
 				if (homesAllowed.equals("unlimited"))
 				{
+					if (Utils.isHomeInConfig(player.getUniqueId(), homeName))
+					{
+						Utils.deleteHome(player, homeName);
+					}
 					Utils.setHome(player.getUniqueId(), player.getTransform(), player.getWorld().getName(), homeName);
 					src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Home set."));
 				}
@@ -67,8 +71,17 @@ public class SetHomeExecutor extends AsyncCommandExecutorBase
 				{
 					Integer allowedHomes = Integer.parseInt(homesAllowed);
 
+					if (Utils.isHomeInConfig(player.getUniqueId(), homeName))
+					{
+						allowedHomes++;
+					}
+
 					if (allowedHomes > Utils.getHomes(player.getUniqueId()).size())
 					{
+						if (Utils.isHomeInConfig(player.getUniqueId(), homeName))
+						{
+							Utils.deleteHome(player, homeName);
+						}
 						Utils.setHome(player.getUniqueId(), player.getTransform(), player.getWorld().getName(), homeName);
 						src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Home set."));
 					}
@@ -80,6 +93,10 @@ public class SetHomeExecutor extends AsyncCommandExecutorBase
 			}
 			else
 			{
+				if (Utils.isHomeInConfig(player.getUniqueId(), homeName))
+				{
+					Utils.deleteHome(player, homeName);
+				}
 				Utils.setHome(player.getUniqueId(), player.getTransform(), player.getWorld().getName(), homeName);
 				src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Home set."));
 			}

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/SetWarpExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/SetWarpExecutor.java
@@ -45,6 +45,10 @@ public class SetWarpExecutor extends AsyncCommandExecutorBase
 
 		if (src instanceof Player)
 		{
+			if (Utils.isWarpInConfig(warpName))
+			{
+				Utils.deleteWarp(warpName);
+			}
 			Player player = (Player) src;
 			Utils.setWarp(player.getTransform(), warpName);
 			src.sendMessage(Text.of(TextColors.GREEN, "Success: ", TextColors.YELLOW, "Warp set."));

--- a/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/WarpExecutor.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/cmdexecutors/WarpExecutor.java
@@ -84,7 +84,7 @@ public class WarpExecutor extends CommandExecutorBase
 										player.setTransform(warpLocation);
 									}
 
-									src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to Warp " + warpName));
+									src.sendMessage(Text.of(TextColors.GREEN, "Success! ", TextColors.YELLOW, "Teleported to warp " + Utils.getConfigWarpName(warpName)));
 									EssentialCmds.teleportingPlayers.remove(player.getUniqueId());
 								}
 							}).delay(Utils.getTeleportCooldown(), TimeUnit.SECONDS).name("EssentialCmds - Back Timer").submit(Sponge.getGame().getPluginManager().getPlugin("EssentialCmds").get().getInstance().get());

--- a/src/main/java/io/github/hsyyid/essentialcmds/utils/Utils.java
+++ b/src/main/java/io/github/hsyyid/essentialcmds/utils/Utils.java
@@ -1082,13 +1082,14 @@ public class Utils
 
 	public static Transform<World> getHome(UUID uuid, String homeName)
 	{
-		String worldName = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "world").getString();
+		CommentedConfigurationNode homeNode = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), getConfigHomeName(uuid, homeName));
+		String worldName = homeNode.getNode("world").getString();
 		World world = Sponge.getServer().getWorld(worldName).orElse(null);
-		double x = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "X").getDouble();
-		double y = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "Y").getDouble();
-		double z = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "Z").getDouble();
+		double x = homeNode.getNode("X").getDouble();
+		double y = homeNode.getNode("Y").getDouble();
+		double z = homeNode.getNode("Z").getDouble();
 
-		if (Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "transform", "pitch").getValue() == null)
+		if (homeNode.getNode("transform", "pitch").getValue() == null)
 		{
 			if (world != null)
 				return new Transform<>(new Location<>(world, x, y, z));
@@ -1097,9 +1098,9 @@ public class Utils
 		}
 		else
 		{
-			double pitch = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "transform", "pitch").getDouble();
-			double yaw = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "transform", "yaw").getDouble();
-			double roll = Configs.getConfig(homesConfig).getNode("home", "users", uuid.toString(), homeName, "transform", "roll").getDouble();
+			double pitch = homeNode.getNode("transform", "pitch").getDouble();
+			double yaw = homeNode.getNode("transform", "yaw").getDouble();
+			double roll = homeNode.getNode("transform", "roll").getDouble();
 
 			if (world != null)
 				return new Transform<>(world, new Vector3d(x, y, z), new Vector3d(pitch, yaw, roll));
@@ -1110,14 +1111,15 @@ public class Utils
 
 	public static Transform<World> getWarp(String warpName)
 	{
-		UUID worldUuid = UUID.fromString(Configs.getConfig(warpsConfig).getNode("warps", warpName, "world").getString());
+		CommentedConfigurationNode warpNode = Configs.getConfig(warpsConfig).getNode("warps", getConfigWarpName(warpName));
+		UUID worldUuid = UUID.fromString(warpNode.getNode("world").getString());
 		World world = Sponge.getServer().getWorld(worldUuid).orElse(null);
 
-		double x = Configs.getConfig(warpsConfig).getNode("warps", warpName, "X").getDouble();
-		double y = Configs.getConfig(warpsConfig).getNode("warps", warpName, "Y").getDouble();
-		double z = Configs.getConfig(warpsConfig).getNode("warps", warpName, "Z").getDouble();
+		double x = warpNode.getNode("X").getDouble();
+		double y = warpNode.getNode("Y").getDouble();
+		double z = warpNode.getNode("Z").getDouble();
 
-		if (Configs.getConfig(warpsConfig).getNode("warps", warpName, "transform", "pitch").getValue() == null)
+		if (warpNode.getNode("transform", "pitch").getValue() == null)
 		{
 			if (world != null)
 				return new Transform<>(new Location<>(world, x, y, z));
@@ -1126,9 +1128,9 @@ public class Utils
 		}
 		else
 		{
-			double pitch = Configs.getConfig(warpsConfig).getNode("warps", warpName, "transform", "pitch").getDouble();
-			double yaw = Configs.getConfig(warpsConfig).getNode("warps", warpName, "transform", "yaw").getDouble();
-			double roll = Configs.getConfig(warpsConfig).getNode("warps", warpName, "transform", "roll").getDouble();
+			double pitch = warpNode.getNode("transform", "pitch").getDouble();
+			double yaw = warpNode.getNode("transform", "yaw").getDouble();
+			double roll = warpNode.getNode("transform", "roll").getDouble();
 
 			if (world != null)
 				return new Transform<>(world, new Vector3d(x, y, z), new Vector3d(pitch, yaw, roll));
@@ -1137,14 +1139,36 @@ public class Utils
 		}
 	}
 
+	public static String getConfigHomeName(UUID uuid, String homeName)
+	{
+		Set<Object> homes = getHomes(uuid);
+		for (Object home : homes)
+		{
+			if (home.toString().equalsIgnoreCase(homeName))
+				return home.toString();
+		}
+		return null;
+	}
+
+	public static String getConfigWarpName(String warpName)
+	{
+		Set<Object> warps = getWarps();
+		for (Object warp : warps)
+		{
+			if (warp.toString().equalsIgnoreCase(warpName))
+				return warp.toString();
+		}
+		return null;
+	}
+
 	public static boolean isHomeInConfig(UUID playerUuid, String homeName)
 	{
-		return Configs.getConfig(homesConfig).getNode("home", "users", playerUuid.toString()).getChildrenMap().keySet().contains(homeName);
+		return getConfigHomeName(playerUuid, homeName) != null;
 	}
 
 	public static boolean isWarpInConfig(String warpName)
 	{
-		return Configs.getConfig(warpsConfig).getNode("warps").getChildrenMap().keySet().contains(warpName);
+		return getConfigWarpName(warpName) != null;
 	}
 
 	public static boolean isSpawnInConfig()
@@ -1187,12 +1211,12 @@ public class Utils
 
 	public static void deleteHome(Player player, String homeName)
 	{
-		Configs.removeChild(homesConfig, new Object[] { "home", "users", player.getUniqueId().toString() }, homeName);
+		Configs.removeChild(homesConfig, new Object[] { "home", "users", player.getUniqueId().toString() }, getConfigHomeName(player.getUniqueId(), homeName));
 	}
 
 	public static void deleteWarp(String warpName)
 	{
-		Configs.removeChild(warpsConfig, new Object[] { "warps" }, warpName);
+		Configs.removeChild(warpsConfig, new Object[] { "warps" }, getConfigWarpName(warpName));
 	}
 
 	public static void savePlayerInventory(Player player, UUID worldUuid)


### PR DESCRIPTION
This commit does not break compatibility with pre-existing config files. The commands /homes and /warps will show the home/warp names with the same casing used when setting them with /sethome and /setwarp. Setting a warp or home when one with different casing already exists will cause it to be overwritten. The code is a little hacky, but it does the job.
